### PR TITLE
Merge arrays in multiple files safely

### DIFF
--- a/lib/active_file/hash_and_array_files.rb
+++ b/lib/active_file/hash_and_array_files.rb
@@ -13,7 +13,7 @@ module ActiveFile
       loaded_files = full_paths.collect { |path| load_path(path) }
 
       if loaded_files.all?{ |file_data| file_data.is_a?(Array) }
-        loaded_files.sum
+        loaded_files.inject([]) { |array, file_data| array + file_data }
       elsif loaded_files.all?{ |file_data| file_data.is_a?(Hash) }
         loaded_files.inject({}) { |hash, file_data| hash.merge(file_data) }
       else


### PR DESCRIPTION
In some Ruby versions, `Array#sum` requires elements to be Integer.